### PR TITLE
Update vertexBufferLayout.h Fixes #5

### DIFF
--- a/AVT_start/AVT_start/Engine/HeaderFiles/vertexBufferLayout.h
+++ b/AVT_start/AVT_start/Engine/HeaderFiles/vertexBufferLayout.h
@@ -29,12 +29,16 @@ private:
 	std::vector<VertexBufferElement> elements;
 	unsigned int stride;
 
+	template<typename T>
+	struct falsey : std::false_type
+	{ };
+
 public:
 	VertexBufferLayout() : stride(0) {}
 
 	template<typename T>
 	static VertexBufferElement getElement(unsigned int count) {
-		static_assert(false); // for non-handled types
+		static_assert(falsey<T>::value); // for non-handled types
 	}
 
 	template<>
@@ -44,7 +48,7 @@ public:
 
 	template<typename T>
 	void push(unsigned int count) {
-		static_assert(false); // for non-handled types
+		static_assert(falsey<T>::value); // for non-handled types
 	}
 
 	template<>


### PR DESCRIPTION
See https://stackoverflow.com/questions/14637356/static-assert-fails-compilation-even-though-template-function-is-called-nowhere